### PR TITLE
specify kernel name when starting new kernel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ class Juniper {
             window.localStorage.setItem(this.storageKey, json);
         }
         const serverSettings = ServerConnection.makeSettings(settings);
-        return Kernel.startNew({ type: this.kernelType, serverSettings })
+        return Kernel.startNew({ type: this.kernelType, name: this.kernelType, serverSettings })
             .then(kernel => {
                 this._event('ready');
                 return kernel;


### PR DESCRIPTION
Closes #3 (at least insofar as I experienced this issue). 

Steps to reproduce:

Create a juniper object:

```
   <pre data-executable>echo "hello"</pre>
   <script src="juniper.min.js"></script>
   <script>
     new Juniper({ repo: 'amn41/bash_plus_kernel/', branch: 'master', kernelType: 'bash', language: 'shell' })
   </script>
```

Attempting to run this will result in a SytaxError because the kernel is python3 by virtue of the default kernel name. Applying this patch fixes the issue & the command executes correctly. 

I re-used the `this.kernelType` option rather than introducing a new `'name'` option because as far as I can tell they are equivalent. Though there could be edge cases where these differ I'm just not aware of them. 